### PR TITLE
Ignore package build on pr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: "Package xbridge_witnessd"
 on:
   push:
     branches: ['main', 'release', 'develop', '*-rc*', '*-b*']
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: "Package xbridge_witnessd"
 on:
   push:
-    branches: ['main', 'release', 'develop', '*-rc*', '*-b*']
+    branches: ['main', 'release', 'develop', '*-rc[0-9]+', '*-b[0-9]+']
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Packages and Docker images should not be built when a PR is submitted.
Also restrict them to release candidate and betas.